### PR TITLE
Overwrite existing results.csv data

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -128,7 +128,7 @@ produce_report()
 		echo Ran > test_results_report
 
 		located=0
-		> results.csv
+		[ -f results.csv ] && rm results.csv
 		while IFS= read -r line
 		do
 			if [[ $line == *"Results Complete:"* ]]; then

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -128,6 +128,7 @@ produce_report()
 		echo Ran > test_results_report
 
 		located=0
+		> results.csv
 		while IFS= read -r line
 		do
 			if [[ $line == *"Results Complete:"* ]]; then


### PR DESCRIPTION
This PR fixes #19. 

The addition of the line `> results.csv` causes the results.csv to be initialized. If a results.csv file already exists from a prior run, the results file will be overwritten and start from scratch instead of appending the new results.