### PR TITLE
Need legacy curses to run on ubuntu.

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -335,5 +335,15 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+#
+# As the passmark kit is old, it needs older libcurses libraries
+# to run on Ubuntu.
+#
+os=`$TOOLS_BIN/detect_os`
+if [[ $os == "ubuntu" ]]; then
+	add-apt-repository universe -y
+	apt-get install libncurses5 -y
+fi
+
 run_passmark
 exit 0


### PR DESCRIPTION
passmark needs to have legacy libcurses to run on latest versions of Ubuntu.

Issue #18 

Relates to JIRA: https://issues.redhat.com/browse/RPOPC-249