### PR TITLE
Make the uploads directory absolute.

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -212,7 +212,7 @@ run_passmark()
 	pushd $curdir > /dev/null
 	if [ ! -d "PerformanceTest" ]; then
 		if [[ $arch == "aarch64" ]]; then
-			unzip uploads/pt_linux_arm64.zip
+			unzip /uploads/pt_linux_arm64.zip
 			if [ $? -ne 0 ]; then
 				exit_out "pt_linux_arm64.zip failed" 1
 			fi
@@ -228,7 +228,7 @@ run_passmark()
 				fi
 			fi
 		else
-			unzip uploads/pt_linux_x64.zip
+			unzip /uploads/pt_linux_x64.zip
 			if [ $? -ne 0 ]; then
 				exit_out "pt_linux_x64.zip failed" 1
 			fi


### PR DESCRIPTION
# Description
Fixes it so the path to uploads is absolute.

# Before/After Comparison
Before: depending on where we are executing from, we may not find the uploaded file
After: The path is absolute, we will always find the uploaded file.

# Clerical Stuff
This closes #32 

Relates to JIRA: RPOPC-424
