### PR TITLE
Update test verification to use reg exps

### DIFF
--- a/passmark/base_test_results/test1/verify
+++ b/passmark/base_test_results/test1/verify
@@ -1,6 +1,6 @@
 #
 #  regexp explanation
-#  :[1-9][0-9.]{0,}$
+#  :[1-9][0-9\.]{0,}$
 #
 #   Field 1:  any match
 #   Field 2 [1-9][0-9\.]{0,}$: Results provided by test. Any non zero decimal value.

--- a/passmark/base_test_results/test1/verify
+++ b/passmark/base_test_results/test1/verify
@@ -1,0 +1,4 @@
+%_header
+NumTestProcesses:[ 0-9. ]{1,}$
+%_multiples
+:[ 1-9 ][ 0-9. ]{0,}$

--- a/passmark/base_test_results/test1/verify
+++ b/passmark/base_test_results/test1/verify
@@ -3,12 +3,12 @@
 #  :[1-9][0-9.]{0,}$
 #
 #   Field 1:  any match
-#   Field 2 [1-9][0-9.]{0,}$: Results provided by test. Any non zero decimal value.
+#   Field 2 [1-9][0-9\.]{0,}$: Results provided by test. Any non zero decimal value.
 #
 %_header
-NumTestProcesses:[0-9.]{1,}$
+NumTestProcesses:[1-9][0-9]{0,}$
 #
 # We can have more than one of the following line.
 #
 %_multiples
-:[1-9][0-9.]{0,}$
+:[1-9][0-9\.]{0,}$

--- a/passmark/base_test_results/test1/verify
+++ b/passmark/base_test_results/test1/verify
@@ -1,15 +1,9 @@
 #
-# Main reg exp summary
-# :[1-9][0-9.]{0,}$
+#  regexp explanation
+#  :[1-9][0-9.]{0,}$
 #
 #   Field 1:  any match
-#   Field 2:  Any non zero decimal value.
-#
-# Detailed description
-# [1-9][0-9.]{0,}$:
-#   [1-9]: This matches a single digit from 1 to 9.
-#   [0-9.]{0,}: This matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
-#   $: This is an anchor that matches the end of the line.
+#   Field 2 [1-9][0-9.]{0,}$: Results provided by test. Any non zero decimal value.
 #
 %_header
 NumTestProcesses:[0-9.]{1,}$

--- a/passmark/base_test_results/test1/verify
+++ b/passmark/base_test_results/test1/verify
@@ -1,4 +1,20 @@
+#
+# Main reg exp summary
+# :[1-9][0-9.]{0,}$
+#
+#   Field 1:  any match
+#   Field 2:  Any non zero decimal value.
+#
+# Detailed description
+# [1-9][0-9.]{0,}$:
+#   [1-9]: This matches a single digit from 1 to 9.
+#   [0-9.]{0,}: This matches zero or more occurrences of either a digit (0-9) or a literal dot (.).
+#   $: This is an anchor that matches the end of the line.
+#
 %_header
-NumTestProcesses:[ 0-9. ]{1,}$
+NumTestProcesses:[0-9.]{1,}$
+#
+# We can have more than one of the following line.
+#
 %_multiples
-:[ 1-9 ][ 0-9. ]{0,}$
+:[1-9][0-9.]{0,}$

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -25,6 +25,8 @@ test_name="passmark"
 results_file="results_${test_name}.csv"
 passmark_version="v1.0"
 curdir=`pwd`
+rtc=0
+
 if [ ! -f "/tmp/${test_name}.out" ]; then
         command="${0} $@"
         echo $command
@@ -265,11 +267,7 @@ run_passmark()
 		done
 		produce_report
 		$TOOLS_BIN/validate_line --results_file $results_file  --base_results_file $run_dir/base_test_results/test1/verify
-		if [[ $? -ne 0 ]]; then
-			echo Failed > test_results_report
-		else
-			echo Ran > test_results_report
-		fi
+		rtc=$?
 		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results $results_file --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user  --other_files "passmark.summary,results_all_*,${test_name}_${iter}.out,test_results_report"
 		cp  results_${test_name}_${to_tuned_setting}.tar results_pbench_${test_name}_${to_tuned_setting}.tar
 		popd > /dev/null
@@ -351,4 +349,4 @@ if [[ $os == "ubuntu" ]]; then
 fi
 
 run_passmark
-exit 0
+exit $rtc

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -22,6 +22,7 @@
 # set of default run parameters based on the system configuration.
 #
 test_name="passmark"
+results_file="results_${test_name}.csv"
 passmark_version="v1.0"
 curdir=`pwd`
 if [ ! -f "/tmp/${test_name}.out" ]; then
@@ -132,9 +133,9 @@ produce_report()
 		echo Ran > test_results_report
 
 		located=0
-		[ -f results.csv ] && rm results.csv
+		[ -f $results_file ] && rm $results_file
 
-		$TOOLS_BIN/test_header_info --front_matter --results_file results.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $passmark_version --test_name $test_name
+		$TOOLS_BIN/test_header_info --front_matter --results_file $results_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $passmark_version --test_name $test_name
 
 		while IFS= read -r line
 		arch=`uname -m`
@@ -156,7 +157,7 @@ produce_report()
 				#
 				continue
 			fi
-			echo $line | sed "s/ //g" >> results.csv
+			echo $line | sed "s/ //g" >> $results_file
 		done < "$summary_file"
 	fi
 	echo Checksum: Not applicable for summary file >> $summary_file
@@ -221,10 +222,8 @@ run_passmark()
 			#
 			uname -a | grep  -q Ubuntu
 			if [ $? -eq 0 ]; then
-				echo ubuntu >> /tmp/dave
 				if [[ ! -f /usr/lib64 ]]; then
 					ln -s /usr/lib /usr/lib64
-					echo ln -s /usr/lib /usr/lib64 >> /tmp/dave
 				fi
 			fi
 		else
@@ -265,7 +264,13 @@ run_passmark()
 			mv results_all.yml results_all_${iter}.yml
 		done
 		produce_report
-		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user  --other_files "passmark.summary,results_all_*,${test_name}_${iter}.out,test_results_report"
+		$TOOLS_BIN/validate_line --results_file $results_file  --base_results_file $run_dir/base_test_results/test1/verify
+		if [[ $? -ne 0 ]]; then
+			echo Failed > test_results_report
+		else
+			echo Ran > test_results_report
+		fi
+		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results $results_file --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user  --other_files "passmark.summary,results_all_*,${test_name}_${iter}.out,test_results_report"
 		cp  results_${test_name}_${to_tuned_setting}.tar results_pbench_${test_name}_${to_tuned_setting}.tar
 		popd > /dev/null
 	else

--- a/passmark/verification_config/test_verify
+++ b/passmark/verification_config/test_verify
@@ -1,0 +1,3 @@
+Required_Systems: intel,amd,arm
+Via_Zathras: No
+test:--iterations 1:base_test_results/test1/verify


### PR DESCRIPTION
# Description
This adds the required files and hooks into the wrapper for verification of the test results via regexp.

Mapping results to regexp
Typical results
NumTestProcesses:96
CPU_INTEGER_MATH:268224.74666666659
CPU_FLOATINGPOINT_MATH:145343.42208022485




Regexp file contents
%_header
NumTestProcesses:[ 0-9. ]{1,}$
%_multiples
:[ 1-9 ][ 0-9. ]{0,}$

%_header: Indicates the next line is a header that we need to match.
Field 1: Matches anything
Field 2: Expects a numerical value greater than 0.

# Before/After Comparison
Before change: Failures will occur on validation
After change: Passes when it should, fails when it should.

# Clerical Stuff
This closes #31 

Relates to JIRA: RPOPC-423

# Testing
Running the wrapper (modifying the regexps to force failures)
Verified test fails when it has bad data
Verified test passes when we have good data.
