### PR TITLE
Replace Pbench with PCP

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -298,7 +298,7 @@ run_passmark()
 		copy_dirs="--copy_dir $copy_dirs"
 	fi
 
-	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user  --other_files "passmark.summary,results_all_*,${test_name}_${iter}.out,test_results_report,$pcp_dir" $copy_dirs
+	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user  --other_files "passmark.summary,results_all_*,${test_name}_${iter}.out,test_results_report" $copy_dirs
 	popd > /dev/null
 }
 


### PR DESCRIPTION
# Description
This PR replaces Pbench with PCP for recording system metrics

# Before/After Comparison
## Before
Pbench support is in, but likely non-functional due to Pbench's sunsetting.

## After
Pbench is no longer supported, and PCP replaces it for recording system metrics.

Additionally all results from this test are available in `openmetrics.workload.passmark_$testName`

# Clerical Stuff
This closes #35 

Relates to JIRA: RPOPC-621
