### PR TITLE
Only for ubuntu: make curses 5 a link to to curses 6 if curses 5 does not exist.

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -27,7 +27,6 @@ curdir=`pwd`
 script_dir=$(dirname $(realpath $0))
 copy_dirs=""
 
-
 if [ ! -f "/tmp/${test_name}.out" ]; then
         command="${0} $@"
         echo $command


### PR DESCRIPTION
# Description
if curses 5 does not exist we will link it to curses 6 as indicated by a web search.

# Before/After Comparison
Before:  passmark will not build on 24.04
After.  passmark builds on 24.04 and runs properly.

# Clerical Stuff
This closes #39 

Relates to JIRA: RPOPC-704
