### PR TITLE
Handle missing libncurses.so.5 and different locations

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -243,13 +243,31 @@ run_passmark()
 
 	if [ ! -f "/usr/lib64/libncurses.so.5" ]; then
 		pushd /usr/lib64 > /dev/null
-		if [[ -f "libncurses.so.6" ]]; then
+		lib=`find . -print | grep libncurses.so.6`
+		if [[ $? -ne 0 ]]; then
+			popd > /dev/null
+			#
+			# Now try /usr/lib
+			#
+			pushd /usr/lib > /dev/null
+			lib=`find . -print | grep  'libncurses.so.6$'`
+			if [[ $? -ne 0 ]]; then
+				#
+				# Give up.
+				#
+				exit_out "/usr/lib64/libncurses.so.6 not present" 1
+			fi
+			if [[ -f "libncurses.so.6" ]]; then
+				ln -s libncurses.so.6 libncurses.so.5
+			else
+				lib=`find . -print | grep  'libncurses.so.6$'`
+				if [[ $? -ne 0 ]]; then
+					exit_out "libncurses.so.6 not present" 1
+				fi
+			fi
+			dir=`echo $lib | rev | cut -d'/' -f2- | rev`
+			cd $dir
 			ln -s libncurses.so.6 libncurses.so.5
-		elif [[ -d "aarch64-linux-gnu" ]]; then
-			cd aarch64-linux-gnu
-			ln -s libncurses.so.6 libncurses.so.5
-		else
-			exit_out "/usr/lib64/libncurses.so.5 not present" 1
 		fi
 		popd > /dev/null
 	fi


### PR DESCRIPTION
# Description
On Ubuntu systems, the libncurses.so.5 may not exists and we need to link to  libncurses.so.5.  The libncurses.so.5  may be in a couple different areas (depending on the arch..  This adds code
to check for that if so link accordingly.  If we can not find the file to link to we will error out.

# Before/After Comparison
Before: On ubuntu, test would fail to run because libncurses was not set up properly.
After: libncurses is set up properly and tests runs
# Clerical Stuff
 
This closes #41 

Relates to JIRA: RPOPC-740

Test info (arm ubuntu)
root@ip-170-0-24-59:/home/ubuntu# ./passmark.cmd
/home/ubuntu/workloads/passmark-wrapper-2.2/passmark/passmark_run --run_user ubuntu --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config m6g.16xlarge --sysname m6g.16xlarge --sys_type aws --iterations 5
WARN: Could not find dependency information for pip in /workloads/passmark-wrapper-2.2/passmark/../passmark.json, this could be intended behavior

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Hit:1 http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports noble InRelease
Hit:2 http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports noble-updates InRelease
Hit:3 http://us-east-2.ec2.ports.ubuntu.com/ubuntu-ports noble-backports InRelease
Hit:4 http://ports.ubuntu.com/ubuntu-ports noble-security InRelease
Reading package lists...
Building dependency tree...
Reading state information...
30 packages can be upgraded. Run 'apt list --upgradable' to see them.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
bc is already the newest version (1.07.1-3ubuntu4).
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
numactl is already the newest version (2.0.18-1build1).
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
git is already the newest version (1:2.43.0-1ubuntu7.3).
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
zip is already the newest version (3.0-13ubuntu0.2).
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
unzip is already the newest version (6.0-28ubuntu4.1).
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libncurses5
/bin/apt install of libncurses5 failed
updating: results_passmark_tuned_none.tar (deflated 84%)

Results file created, test ran.

