### PR TITLE
Use multiple pcp records

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -89,9 +89,9 @@ summary_file="passmark.summary"
 rm $summary_file
 pull_data()
 {
+	ltest_name="$1"
 	passmark_file=`mktemp /tmp/passmark_data.XXXXX`
-	test_name=${1}
-	grep "^${test_name}" results_all_*yml | cut -d':' -f2 | sed "s/ //g" > ${passmark_file}
+	grep "^${ltest_name}" results_all_*yml | cut -d':' -f2 | sed "s/ //g" > ${passmark_file}
 	results=0.0
 	iterations=0
 	while IFS= read -r line
@@ -102,7 +102,7 @@ pull_data()
 	done < "${passmark_file}"
 	rm ${passmark_file}
 	value=`echo "scaling=12;${results}/${iterations}" | bc -l`
-	output=`printf "  %s:%-40.12f" $test_name $value | sed "s/ //g" | sed "s/:/: /g"`
+	output=`printf "  %s:%-40.12f" $ltest_name $value | sed "s/ //g" | sed "s/:/: /g"`
 	echo "${output}"
 }
 
@@ -117,6 +117,8 @@ usage()
 
 produce_report()
 {
+	start_time="${1}"
+	end_time="${2}"
 	found=0
 
 	if [[ ! -f  results_all_1.yml ]]; then
@@ -126,8 +128,8 @@ produce_report()
 		do
 			if [[ $found -eq 1 ]]; then
 				if [[ ${line} != "SystemInformation:"* ]]; then
-					test_name=`echo $line | awk '{print $1}'`
-					pull_data $test_name
+					ltest_name=`echo $line | awk '{print $1}'`
+					pull_data $ltest_name
 					continue
 				else
 					found=0
@@ -143,11 +145,11 @@ produce_report()
 		located=0
 		[ -f results.csv ] && rm results.csv
 
-		$TOOLS_BIN/test_header_info --front_matter --results_file results.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $passmark_version --test_name $test_name
+		$TOOLS_BIN/test_header_info --front_matter --results_file results.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $passmark_version --test_name $test_name --field_header "Testname,Operations"
 
 		while IFS= read -r line
 		do
-			if [[ $line == *"Results Complete:"* ]]; then
+			if [[ $line == *"NumTestProcesses:"* ]]; then
 				located=1
 				continue
 			fi
@@ -164,7 +166,10 @@ produce_report()
 				#
 				continue
 			fi
-			echo $line | sed "s/ //g" >> results.csv
+			ltest_name=`echo $line | cut -d':' -f1`
+			results=`echo $line | cut -d' ' -f2`
+			data_string=$(build_data_string "${ltest_name}" "${results}" "${start_time}" "${end_time}")
+			echo "${data_string}" >> results.csv
 		done < "$summary_file"
 	fi
 	echo Checksum: Not applicable for summary file >> $summary_file
@@ -282,7 +287,6 @@ run_passmark()
 	rm passmark.summary
 
 	if [[ $to_use_pcp -eq 1 ]]; then
-		source $TOOLS_BIN/pcp/pcp_commands.inc
 		setup_pcp
 		pcp_cfg=$TOOLS_BIN/pcp/default.cfg
 		pcp_dir=/tmp/pcp_passmark_$(date +%Y.%m.%d-%H.%M.%S)
@@ -294,6 +298,7 @@ run_passmark()
 		if [[ $to_use_pcp -eq 1 ]];then
 			start_pcp_subset
 		fi
+		start_time=$(retrieve_time_stamp)
 		if [[ $arch == "aarch64" ]]; then
 			./pt_linux_arm64 -r 3 >> ${test_name}_${iter}.out
 			if [ $? -ne 0 ]; then
@@ -305,6 +310,7 @@ run_passmark()
 				exit_out "Execution of ./pt_linux_x64 failed" 1
 			fi
 		fi
+		end_time=$(retrieve_time_stamp)
 		mv results_all.yml results_all_${iter}.yml		
 		if [[ $to_use_pcp -eq 1 ]]; then
 			results2pcp_add_value "iteration:$iter"
@@ -330,7 +336,7 @@ run_passmark()
 		fi
 	done
 
-	produce_report
+	produce_report "${start_time}" "${end_time}"
 	if [[ $to_use_pcp -eq 1 ]]; then
 		stop_pcp
 	fi
@@ -359,6 +365,9 @@ install_tools "$@"
 #
 
 source ${curdir}/test_tools/general_setup "$@"
+if [[ $to_use_pcp -eq 1 ]]; then
+	source $TOOLS_BIN/pcp/pcp_commands.inc
+fi
 
 ARGUMENT_LIST=(
 	"cpu_add"

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -307,21 +307,25 @@ run_passmark()
 		fi
 		mv results_all.yml results_all_${iter}.yml		
 		if [[ $to_use_pcp -eq 1 ]]; then
-			result2pcp iteration $iter
+			results2pcp_add_value "iteration:$iter"
 			while IFS= read -r metric
 			do
 				field=`echo $metric | awk '{print $1}'`
-				grep -q ^${field} results_all_${iter}.yml
+				grep -q "^  ${field}:" results_all_${iter}.yml
 				#
 				# Only if the metric exists
 				#
 				if [[ $? -eq 0 ]]; then
-					value=`grep ^$field results_all_${iter}.yml | cut -d':' -f2`
-					result2pcp $field $value
-				#
-				# If the 
+					value=`grep "^  ${field}:" results_all_${iter}.yml | awk '{print $2}'`
+					results2pcp_add_value "$field:$value"
 				fi
 			done < "${run_dir}/openmetrics_passmark_reset.txt"
+			results2pcp_add_value_commit
+			#
+			# Now zero everything but the iteration
+			#
+			reset_pcp_om
+			results2pcp_multiple "iteration:$iter"
 			stop_pcp_subset
 		fi
 	done


### PR DESCRIPTION
# Description
Adds in the pcp openmetric hooks to save the test metrics.
Replaces : with , in csv file.  Also adds timestamps to the csv files

# Before/After Comparison
Before: no test metrics saved
After: Test metrics are saved.

# Clerical Stuff
This closes #45 

Relates to JIRA: RPOPC-773

Test Results

Command executed
/home/ec2-user/workloads/passmark-wrapper/passmark/passmark_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.xlarge" --sysname "m7i.xlarge" --sys_type aws  --use_pcp

CSV file
Testname,Operations,Start_Date,End_Date
CPU_INTEGER_MATH,40334.461000000003,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_FLOATINGPOINT_MATH,28721.002086739063,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_PRIME,81.520067600075365,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_SORTING,19781.488957495156,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_ENCRYPTION,8940.2630041828434,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_COMPRESSION,145575.62523764776,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_SINGLETHREAD,3077.7804575361638,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_PHYSICS,1834.7581027689062,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_MATRIX_MULT_SSE,10847.511593763154,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_mm,1140.9642152765609,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_sse,4831.4803111192668,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_fma,10873.600679253432,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_avx,10265.156102971243,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
CPU_avx512,17419.809281708676,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
m_CPU_enc_SHA,9399882078.1346302,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
m_CPU_enc_AES,12234534184.020908,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
m_CPU_enc_ECDSA,6489219397.4665499,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_ALLOC_S,4534.3019599117051,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_READ_S,27522.304101562499,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_READ_L,9680.9853515625,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_WRITE,13274.326171875,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_LARGE,30023.916666666668,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_LATENCY,80.824139914450697,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
ME_THREADED,51003.33984375,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
SUMM_CPU,14741.862987199984,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z
SUMM_ME,2106.6154524154513,2026-01-27T20:46:33Z,2026-01-27T20:49:09Z

pcp output (truncated)
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.CPU_INTEGER_MATH  o.w.CPU_FLOATINGPOINT_MATH  o.w.CPU_PRIME  o.w.CPU_SORTING  o.w.CPU_ENCRYPTION  o.w.CPU_COMPRESSION  o.w.CPU_SINGLETHREAD  o.w.CPU_PHYSICS  o.w.CPU_MATRIX_MULT_SSE  o.w.CPU_mm  o.w.CPU_sse  o.w.CPU_fma  o.w.CPU_avx  o.w.CPU_avx512  o.w.m_CPU_enc_SHA  o.w.m_CPU_enc_AES  o.w.m_CPU_enc_ECDSA  o.w.ME_ALLOC_S  o.w.ME_READ_S  o.w.ME_READ_L  o.w.ME_WRITE  o.w.ME_LARGE  o.w.ME_LATENCY  o.w.ME_THREADED  o.w.SUMM_CPU  o.w.SUMM_ME
20:49:09          1.000        1.000           0.000          NaN             NaN          NaN             40334.461                   28721.002         81.520        19781.489            8940.263           145575.625              3077.780         1834.758                10847.512    1140.964     4831.480    10873.601    10265.156       17419.809     9399882078.135    12234534184.021       6489219397.467        4534.302      27522.304       9680.985     13274.326     30023.917          80.824        51003.340     14741.863     2106.615
20:49:10          1.000        1.000           0.000          NaN             NaN          NaN             40334.461                   28721.002         81.520        19781.489            8940.263           145575.625              3077.780         1834.758                10847.512    1140.964     4831.480    10873.601    10265.156       17419.809     9399882078.135    12234534184.021       6489219397.467        4534.302      27522.304       9680.985     13274.326     30023.917          80.824        51003.340     14741.863     2106.615



-x output
[passmark.txt](https://github.com/user-attachments/files/24749783/passmark.txt)

