### PR TITLE
Fix uploads and libncurses fixup

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -226,7 +226,7 @@ run_passmark()
 	pushd $curdir > /dev/null
 	if [ ! -d "PerformanceTest" ]; then
 		if [[ $arch == "aarch64" ]]; then
-			unzip /uploads/pt_linux_arm64.zip
+			unzip /$to_home_root/$to_user/uploads/pt_linux_arm64.zip
 			if [ $? -ne 0 ]; then
 				exit_out "pt_linux_arm64.zip failed" 1
 			fi
@@ -240,7 +240,7 @@ run_passmark()
 				fi
 			fi
 		else
-			unzip /uploads/pt_linux_x64.zip
+			unzip /$to_home_root/$to_user/uploads/pt_linux_x64.zip
 			if [ $? -ne 0 ]; then
 				exit_out "pt_linux_x64.zip failed" 1
 			fi


### PR DESCRIPTION
# Description
This fixes two separate issues preventing passmark from running.  First, the uploads directory is no longer /uploads - it was moved to be (possibly a simlink) in the user's home directory.  Second, the libncurses symlink fixup logic was broken - it would only work if it found libncurses.so.6 in /usr/lib rather than in /usr/lib64; the new logic works for both cases.

# Before/After Comparison
Before: the benchmark would fail to run as it could not find the passmark kit in /uploads, and when that was fixed the libncurses failure would terminate the wrapper - interestingly at that failure it would call stop_pcp_subset() which would then hang because PCPrecord had never been started, this was a neat rabbit hole that distracted from the real problem.

After: 
The benchmark runs to completion

Cleaned up pmrep output:
`          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.CPU_INTEGER_MATH  o.w.CPU_FLOATINGPOINT_MATH  o.w.CPU_PRIME  o.w.CPU_SORTING  o.w.CPU_ENCRYPTION  o.w.CPU_COMPRESSION  o.w.CPU_SINGLETHREAD  o.w.CPU_PHYSICS  o.w.CPU_MATRIX_MULT_SSE  o.w.CPU_mm  o.w.CPU_sse  o.w.CPU_fma  o.w.CPU_avx  o.w.CPU_avx512  o.w.m_CPU_enc_SHA  o.w.m_CPU_enc_AES  o.w.m_CPU_enc_ECDSA  o.w.ME_ALLOC_S  o.w.ME_READ_S  o.w.ME_READ_L  o.w.ME_WRITE  o.w.ME_LARGE  o.w.ME_LATENCY  o.w.ME_THREADED  o.w.SUMM_CPU  o.w.SUMM_ME
...
13:33:32          1.000        1.000           0.000          NaN             NaN          NaN             16435.198                   11699.001         35.005         8089.286            3630.360            61815.124              2530.946          819.151                 4486.269     457.609     1901.667     5310.787     3905.296        6827.328     3851543651.376     4943662644.153       2624919905.740        2451.197      23458.014       9619.224      8790.903     13044.833          72.538        28169.933      6306.680     1906.537
13:33:33          1.000        1.000           0.000          NaN             NaN          NaN             16435.198                   11699.001         35.005         8089.286            3630.360            61815.124              2530.946          819.151                 4486.269     457.609     1901.667     5310.787     3905.296        6827.328     3851543651.376     4943662644.153       2624919905.740        2451.197      23458.014       9619.224      8790.903     13044.833          72.538        28169.933      6306.680     1906.537
`

# Clerical Stuff
This closes #49 
This closes #50 

Relates to JIRA: RPOPC-836
Relates to JIRA: RPOPC-837
[passmark-x.log](https://github.com/user-attachments/files/25267389/passmark-x.log)
