### PR TITLE
Update error codes to be more specific

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -111,7 +111,7 @@ usage()
 	echo "  --cpu_add n: add n cpus each iteration until hit max cpus"
 	echo "  --powers_2: starting from 1 cpu, keep doubling the cpus until max cpus"
 	source ${TOOLS_BIN}/general_setup --usage
-	exit 1
+	exit $E_USAGE
 }
 
 produce_report()
@@ -203,7 +203,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 1
+                        exit_out "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }
@@ -260,7 +260,7 @@ run_passmark()
 		if [[ $arch == "aarch64" ]]; then
 			unzip /$to_home_root/$to_user/uploads/pt_linux_arm64.zip
 			if [ $? -ne 0 ]; then
-				exit_out "pt_linux_arm64.zip failed" 1
+				exit_out "pt_linux_arm64.zip failed" $E_GENERAL
 			fi
 			#
 			# Ubuntu check
@@ -274,7 +274,7 @@ run_passmark()
 		else
 			unzip /$to_home_root/$to_user/uploads/pt_linux_x64.zip
 			if [ $? -ne 0 ]; then
-				exit_out "pt_linux_x64.zip failed" 1
+				exit_out "pt_linux_x64.zip failed" $E_GENERAL
 			fi
 		fi
 	fi
@@ -293,14 +293,14 @@ run_passmark()
 				#
 				# Give up.
 				#
-				exit_out "/usr/lib64/libncurses.so.6 not present" 1
+				exit_out "/usr/lib64/libncurses.so.6 not present" $E_GENERAL
 			fi
 			if [[ -f "libncurses.so.6" ]]; then
 				ln -s libncurses.so.6 libncurses.so.5
 			else
 				lib=`find . -print | grep  'libncurses.so.6$'`
 				if [[ $? -ne 0 ]]; then
-					exit_out "libncurses.so.6 not present" 1
+					exit_out "libncurses.so.6 not present" $E_GENERAL
 				fi
 			fi
 		fi
@@ -335,12 +335,12 @@ run_passmark()
 		if [[ $arch == "aarch64" ]]; then
 			./pt_linux_arm64 -r 3 >> ${test_name}_${iter}.out
 			if [ $? -ne 0 ]; then
-				exit_out "Execution of ./pt_linux_arm64 failed" 1
+				exit_out "Execution of ./pt_linux_arm64 failed" $E_GENERAL
 			fi
 		else
 			./pt_linux_x64 -r 3 >> ${test_name}_${iter}.out
 			if [ $? -ne 0 ]; then
-				exit_out "Execution of ./pt_linux_x64 failed" 1
+				exit_out "Execution of ./pt_linux_x64 failed" $E_GENERAL
 			fi
 		fi
 		end_time=$(retrieve_time_stamp)

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -174,6 +174,40 @@ produce_report()
 	echo Checksum: Not applicable for summary file >> $summary_file
 }
 
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 1
+                fi
+        fi
+}
+
 install_tools()
 {
 	pushd $curdir > /dev/null
@@ -208,12 +242,10 @@ install_tools()
 	#
 	TOOLS_BIN=${HOME}/test_tools
 	export TOOLS_BIN
-	if [ ! -d "${TOOLS_BIN}" ]; then
-		git clone $tools_git ${TOOLS_BIN}
-		if [ $? -ne 0 ]; then
-			exit_out "pulling git $tools_git failed." 1
-		fi
-	fi
+
+	attempt_tools_wget
+	attempt_tools_curl
+	attempt_tools_git
 
 	if [ $show_usage -eq 1 ]; then
 		usage $1

--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -174,22 +174,11 @@ produce_report()
 	echo Checksum: Not applicable for summary file >> $summary_file
 }
 
-attempt_tools_wget()
+attempt_tools_generic()
 {
+	method="$1"
         if [[ ! -d "$TOOLS_BIN" ]]; then
-                wget ${tools_git}/archive/refs/heads/main.zip
-                if [[ $? -eq 0 ]]; then
-                        unzip -q main.zip
-                        mv test_tools-wrappers-main ${TOOLS_BIN}
-                        rm main.zip
-                fi
-        fi
-}
-
-attempt_tools_curl()
-{
-        if [[ ! -d "$TOOLS_BIN" ]]; then
-                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                $method ${tools_git}/archive/refs/heads/main.zip
                 if [[ $? -eq 0 ]]; then
                         unzip -q main.zip
                         mv test_tools-wrappers-main ${TOOLS_BIN}
@@ -243,8 +232,8 @@ install_tools()
 	TOOLS_BIN=${HOME}/test_tools
 	export TOOLS_BIN
 
-	attempt_tools_wget
-	attempt_tools_curl
+	attempt_tools_generic "wget"
+	attempt_tools_generic "curl -L -O "
 	attempt_tools_git
 
 	if [ $show_usage -eq 1 ]; then


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #52 


Relates to JIRA: RPOPC-872

Testing Performed
scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: documentation
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "passmark"
    host_config: "m5.xlarge"


csv file generated
Testname,Operations,Start_Date,End_Date
CPU_INTEGER_MATH,11308.477666666666,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_FLOATINGPOINT_MATH,6075.8626372982999,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_PRIME,25.737857519365743,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_SORTING,6044.1112175549915,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_ENCRYPTION,1561.2353118758415,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_COMPRESSION,49482.996629311383,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_SINGLETHREAD,1806.783811132548,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_PHYSICS,513.0180636499947,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_MATRIX_MULT_SSE,2917.7665402382136,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_mm,343.83665038348119,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_sse,1232.2354716647751,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_fma,3659.271431306805,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_avx,2583.1311089885121,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
CPU_avx512,4196.4281489927616,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
m_CPU_enc_SHA,512291001.75296998,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
m_CPU_enc_AES,3943809322.454628,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
m_CPU_enc_ECDSA,455121310.94896895,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_ALLOC_S,1354.8967892590651,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_READ_S,22248.570703124999,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_READ_L,11637.0166015625,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_WRITE,10336.931640625,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_LARGE,12402.666666666666,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_LATENCY,51.850149827299241,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
ME_THREADED,25392.56982421875,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
SUMM_CPU,3975.3374521977503,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z
SUMM_ME,2133.6243122691976,2026-03-13T16:43:28Z,2026-03-13T16:46:01Z


Returned 0 as expected. Testing on rerun verification handled in the appropriate zathras pr.
