### PR TITLE
Use package_tool call in general_setup

### DIFF
--- a/passmark/passmark_run
+++ b/passmark/passmark_run
@@ -428,7 +428,7 @@ elif [[ $os == "sles" ]]; then
 	SUSEConnect --product sle-module-legacy/$($TOOLS_BIN/detect_os --os-version)/$(arch)
 fi
 
-$TOOLS_BIN/package_tool --no_packages $to_no_pkg_install --wrapper_config $script_dir/../passmark.json
+package_tool --no_packages $to_no_pkg_install --wrapper_config $script_dir/../passmark.json
 
 run_passmark
 exit $rtc


### PR DESCRIPTION
# Description
Replacing ${TOOLS_BIN}/package_tool with package_tool so we use the wrapper in general_setup

# Before/After Comparison
Before: Calling package_tool script directly, possible impacting options passed
After: Using the wrapper around package_tools


# Clerical Stuff
This closes #54 


Relates to JIRA: RPOPC-893

Testing
Verified the wrapper still ran as expected.
CSV File generate

Testname,Operations,Start_Date,End_Date
CPU_INTEGER_MATH,11288.929,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_FLOATINGPOINT_MATH,6065.6871768904712,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_PRIME,26.191904727691217,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_SORTING,5979.6382344105268,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_ENCRYPTION,1559.1576984585081,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_COMPRESSION,49632.212325347173,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_SINGLETHREAD,1810.875447675279,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_PHYSICS,503.53647215941169,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_MATRIX_MULT_SSE,2976.0377097979517,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_mm,321.39853477242787,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_sse,1235.4613356160021,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_fma,3655.3050369634238,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_avx,2579.8827470511337,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
CPU_avx512,4433.5017195612472,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
m_CPU_enc_SHA,511041513.58460283,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
m_CPU_enc_AES,3939928870.0300632,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
m_CPU_enc_ECDSA,453715644.8418197,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_ALLOC_S,1375.9428637130113,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_READ_S,22320.7373046875,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_READ_L,11744.078125,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_WRITE,10657.822265625,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_LARGE,12188.916666666666,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_LATENCY,52.061798540696891,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
ME_THREADED,26441.02734375,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
SUMM_CPU,3979.0524037948894,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z
SUMM_ME,2150.7320479239866,2026-03-20T15:30:55Z,2026-03-20T15:33:28Z

