### PR TITLE
Change "greater than" to "greater than or equal to" in results validation to handle problem subtests

### DIFF
--- a/passmark/results_schema.py
+++ b/passmark/results_schema.py
@@ -33,6 +33,6 @@ class testname(Enum):
 
 class Passmark_Results(pydantic.BaseModel):
     Testname: testname
-    Operations: float = pydantic.Field(gt=0, allow_inf_nan=False)
+    Operations: float = pydantic.Field(ge=0, allow_inf_nan=False)
     Start_Date: datetime.datetime
     End_Date: datetime.datetime


### PR DESCRIPTION
# Description
This allows the validator to consider a zero result for a subtest as "valid but error", allowing the "good" results to clear validation and be saved off. One example is if a system doesn't support the CPU_avx512 test a zero is returned, which is a valid "something went wrong here but everyone else is okay" result.

# Before/After Comparison
Before:
If one of the subtests returns a zero reflecting an error in one of the subtests, the validation rejects the entire run
Sample:
CPU_fma,144077.57151551355,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
CPU_avx,118863.51315704771,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
CPU_avx512,0,2026-06-08T15:37:26Z,2026-06-08T15:40:29ZCPU_fma,144077.57151551355,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
CPU_avx,118863.51315704771,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
CPU_avx512,0,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
m_CPU_enc_SHA,219491544665.70303,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
m_CPU_enc_AES,141409149289.58951,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
m_CPU_enc_SHA,219491544665.70303,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z
m_CPU_enc_AES,141409149289.58951,2026-06-08T15:37:26Z,2026-06-08T15:40:29Z

1 validation error for list[Passmark_Results]
13.Operations
  Input should be greater than 0 [type=greater_than, input_value=0.0, input_type=float]

After:
After changing the greater_than to greater_equal the validation returns:
Results verified
updating: results_passmark_throughput-performance.tar (deflated 96%)

and the full results are supported.

# Clerical Stuff
This closes #58 
Relates to JIRA: RPOPC-1276
